### PR TITLE
Add documentation about icingacli checks against Elasticsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ allows you to display data collected by [Beats](https://www.elastic.co/products/
 [Logstash](https://www.elastic.co/products/logstash) and any other source. After you've installed and configured the
 module, you can browse events via the host action **Elasticsearch Events**.
 
+It also brings a command for `icingacli`which can be used to query Elasticsearch for certain events. This command
+can be used to create Icinga 2 checks.
+
 ![Icinga Web 2 Module Elasticsearch](doc/res/screenshots/99-Overview.png)
 
 ## Requirements
@@ -36,6 +39,8 @@ General Public License Version 2, you will find a copy of this license in the
 
 Please have a look at our [installation instructions](doc/02-Installation.md) and how to
 [configure](doc/03-Configuration.md) the module.
+
+For running checks you can refer to the [checks](doc/04-Checks.md) chapter.
 
 ## Documentation
 

--- a/doc/04-Checks.md
+++ b/doc/04-Checks.md
@@ -1,0 +1,16 @@
+# Icinga 2 Checks
+
+This module brings an `icingacli` command to check if certain events are present in Elasticsearch.
+
+## Example
+
+The following will check if there are more than 3 (warning) or 5 (critical) events of severity `critical` from the host `www.example.com` in the data from the last hour.
+
+* The `instance` is the same which was set in the modules configuration
+* The values of `crit` and `warn` are just numerical thresholds
+* `index` is set to an index pattern in Elasticsearch. It's a pattern that has to match all index names to search
+* As a `filter` the check takes a filter in Icinga Web 2's filter syntax. These are comparisons of fields in Elasticsearch to values
+
+```
+# icingacli elasticsearch check --instance elasticsearch --crit 5 --warn 3 --index logstash* --filter "beat.hostname=www.example.com AND severity=critical" --from -1h 
+```


### PR DESCRIPTION
This will add documentation about the already present `icingacli` command for checking against Elasticsearch.

fixes #41