### PR TITLE
quick fix for "count(): Parameter must be an array or an object that …

### DIFF
--- a/library/vendor/iplx/Http/Client.php
+++ b/library/vendor/iplx/Http/Client.php
@@ -177,7 +177,7 @@ class Client implements ClientInterface
             curl_getinfo($ch, CURLINFO_HTTP_CODE), $handle->responseHeaders, $handle->responseBody
         );
 
-        if (count($this->handles) >= self::MAX_HANDLES) {
+        if (is_array($this->handles) && count($this->handles) >= self::MAX_HANDLES) {
             curl_close($ch);
         } else {
             curl_reset($ch);


### PR DESCRIPTION
…implements Countable" in PHP 7.2

Bug:
when the first handle will be executed and $this->handles is checked the first time, it is NULL, so PHP throws an error:

```
count(): Parameter must be an array or an object that implements Countable
#0 [internal function]: Icinga\Application\ApplicationBootstrap->Icinga\Application\{closure}(Integer, String, String, Integer, Array)
#1 /usr/share/icingaweb2/modules/elasticsearch/library/vendor/iplx/Http/Client.php(180): count(NULL)
#2 /usr/share/icingaweb2/modules/elasticsearch/library/vendor/iplx/Http/Client.php(195): iplx\Http\Client->executeHandle(Object(iplx\Http\Handle))
#3 /usr/share/icingaweb2/modules/elasticsearch/library/Elasticsearch/Query.php(147): iplx\Http\Client->send(Object(iplx\Http\Request), Array)
#4 /usr/share/icingaweb2/modules/elasticsearch/library/Elasticsearch/Query.php(178): Icinga\Module\Elasticsearch\Query->execute()
#5 /usr/share/icingaweb2/modules/elasticsearch/application/controllers/EventsController.php(106): Icinga\Module\Elasticsearch\Query->fetchAll()
#6 /usr/share/icingaweb2/library/vendor/Zend/Controller/Action.php(507): Icinga\Module\Elasticsearch\Controllers\EventsController->indexAction()
#7 /usr/share/php/Icinga/Web/Controller/Dispatcher.php(76): Zend_Controller_Action->dispatch(String)
#8 /usr/share/icingaweb2/library/vendor/Zend/Controller/Front.php(937): Icinga\Web\Controller\Dispatcher->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#9 /usr/share/php/Icinga/Application/Web.php(300): Zend_Controller_Front->dispatch(Object(Icinga\Web\Request), Object(Icinga\Web\Response))
#10 /usr/share/php/Icinga/Application/webrouter.php(104): Icinga\Application\Web->dispatch()
#11 /usr/share/icingaweb2/public/index.php(4): require_once(String)
#12 {main}

```

Env:
on default Ubuntu 18.04 with icinga2, icingaweb2 und php-fpm (7.2.15) (all defaults)

Sev: critical
- plugin is basically useless

Solution:
- check if $this->handles is an array before calling count($this->handles)

Other solutions (not tested)
- make $this->handles and array by default
- add $ch to handles array before check count($this->handles)