### PR TITLE
Sort columns by selected fields

### DIFF
--- a/library/Elasticsearch/Query.php
+++ b/library/Elasticsearch/Query.php
@@ -163,11 +163,25 @@ class Query implements Queryable, Paginatable
         $events = $this->response['hits']['hits'];
 
         $fields = [];
+        $dummyarr = [];
+        $sortedevent = [];
 
         if (! empty($events)) {
             $event = reset($events);
-
-            Elastic::extractFields($event['_source'], $fields);
+            $sourcedata=($event['_source']);
+            $sortedevent['@timestamp']=$sourcedata['@timestamp'];
+            foreach ($this->fields as $myfield) {
+                if ((strpos($myfield, '.') !== false)) {
+                    $strparts = explode(".", $myfield);
+                    $mynewfield=$strparts[0];
+                    $mynewfield2=$strparts[1];
+                    $dummyarr[$mynewfield2]="NULL";
+                    $sortedevent[$mynewfield]=$dummyarr;
+                    continue;
+                }
+                $sortedevent[$myfield]="NULL";
+            }
+            Elastic::extractFields($sortedevent, $fields);
         }
 
         return $fields;


### PR DESCRIPTION
Sort the columns displayed by the order you select the fields in event type definition.
Before they were displayed in the order elastic returned them in json object. But Json order is random.
This creates a new array in order of the fields an passes it to extractFields function.
If there is a dot in fieldname i assume that the content is an array (for example geoip.countryname, geoip.ip, etc.).